### PR TITLE
Update MDWrapperWebServiceMock.cls

### DIFF
--- a/custom_md_loader/classes/MDWrapperWebServiceMock.cls
+++ b/custom_md_loader/classes/MDWrapperWebServiceMock.cls
@@ -27,6 +27,9 @@ global class MDWrapperWebServiceMock implements WebServiceMock {
                 sr.success = true;
                 respElt.result.add(sr);
                 response.put('response_x', respElt);
+        	} else if (responseType == 'MetadataService.upsertMetadataResponse_element') {
+        		MetadataService.upsertMetadataResponse_element respElt = new MetadataService.upsertMetadataResponse_element();
+        		response.put('response_x', respElt);
         	}
    }
 }


### PR DESCRIPTION
As per Issue #5 and http://salesforce.stackexchange.com/q/151516/102, the test cases in CustomMetadataUploadControllerTest were failing with a Null Pointer Exception when a mock callout was made to upsertMetadata. I added a blank response, which was sufficient to get the test case passing for production deployments.