### PR TITLE
Add notes about CLI plugin to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Using CLI Commands
+
+Salesforce CLI commands for custom metadata types are available in v49. The custom metadata loader is no longer supported or maintained. As such, Salesforce does not guarantee the functionality or performance of the loader. 
+
+The CLI commands simplify development and help you build automation and synchronize your source from scratch orgs when working with custom metadata types. CLI commands offer more functionality than the custom metadata loader. You can create custom metadata types, generate fields, create records, bulk insert records from a CSV file, and generate custom metadata types from an sObject. In addition, there's no limit on the number of records that can be loaded. 
+
+See the following for more information,
+
+* [Create and Manage Custom Metadata Types Using CLI](https://help.salesforce.com/articleView?id=custommetadatatypes_cli.htm)	
+* [cmdt Commands](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_cmdt.htm#cli_reference_force_cmdt) 
+
 # Custom Metadata Loader
 
 <a href="https://githubsfdeploy.herokuapp.com">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Salesforce CLI commands for custom metadata types are available in v49. The cust
 
 The CLI commands simplify development and help you build automation and synchronize your source from scratch orgs when working with custom metadata types. CLI commands offer more functionality than the custom metadata loader. You can create custom metadata types, generate fields, create records, bulk insert records from a CSV file, and generate custom metadata types from an sObject. In addition, there's no limit on the number of records that can be loaded. 
 
-See the following for more information,
+See the following for more information:
 
 * [Create and Manage Custom Metadata Types Using CLI](https://help.salesforce.com/articleView?id=custommetadatatypes_cli.htm)	
 * [cmdt Commands](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_cmdt.htm#cli_reference_force_cmdt) 


### PR DESCRIPTION
The sfdx force:cmdt:* commands are available in CLI v49. Since these commands provide the same functionality as the Custom Metadata Loader, we're adding a notice to its readme to direct users to use the CLI as a replacement for CML.