### PR TITLE
Update MetadataUtil.cls

### DIFF
--- a/custom_md_loader/classes/MetadataUtil.cls
+++ b/custom_md_loader/classes/MetadataUtil.cls
@@ -64,9 +64,10 @@ public class MetadataUtil {
 	       // it would pass the conditions under isHeadervalid() 
         Set<String> fieldNameSet = new Set<String>();  
         for (String fieldNames :header) {
-            if (String.isBlank(fieldNames)) {
-                continue;
-            }
+            //removed following lines as redundant, since if any columns have a blank header, they are captured by 'Header must contain the api names of the fields' error
+            //if (String.isBlank(fieldNames)) {
+            //    continue;
+            //}
 
             fieldNameSet.addAll(fieldNames.split(';'));
         }
@@ -87,9 +88,10 @@ public class MetadataUtil {
             List<String> fieldValueList = new List<String>();
 
             for (String singleRowFieldValues :singleRowOfValues) {
-                if (String.isBlank(singleRowFieldValues)) {
-                    continue;
-                }
+		//Removed following lines as they cause values to become misaligned from headers when CSV contains null values
+		//if (String.isBlank(singleRowFieldValues)) {
+                //    continue;
+                //}
             
                 fieldValueList.addAll(singleRowFieldValues.split(';'));
             }


### PR DESCRIPTION
Relates to issue https://github.com/forcedotcom/CustomMetadataLoader/issues/45

I assume these lines were originally introduced to handle poorly formatted CSV with blank 'columns' at the end.  If there was another reason, then this fix may not be valid.

Simply removing these lines allows correctly formatted CSV with empty values to be handled correctly.